### PR TITLE
Fix inverted vertical mouse cursor (Closes #28)

### DIFF
--- a/src/xaos/platform/lwjgl3/input/Keyboard.java
+++ b/src/xaos/platform/lwjgl3/input/Keyboard.java
@@ -46,8 +46,6 @@ public final class Keyboard {
     public static final int KEY_X = GLFW_KEY_X;
     public static final int KEY_Y = GLFW_KEY_Y;
     public static final int KEY_Z = GLFW_KEY_Z;
-    public static final int KEY_F5 = GLFW_KEY_F5;
-    public static final int KEY_F6 = GLFW_KEY_F6;
     public static final int KEY_BACK = GLFW_KEY_BACKSPACE;
     public static final int KEY_DELETE = GLFW_KEY_DELETE;
     public static final int KEY_DIVIDE = GLFW_KEY_KP_DIVIDE;
@@ -92,8 +90,9 @@ public final class Keyboard {
         register("SLASH", KEY_SLASH);
         register("SPACE", KEY_SPACE);
         register("UP", KEY_UP);
-        register("F5", KEY_F5);
-        register("F6", KEY_F6);
+        for (int fn = 1; fn <= 12; fn++) {
+            register("F" + fn, GLFW_KEY_F1 + fn - 1);
+        }
         for (char c = 'A'; c <= 'Z'; c++) {
             register(String.valueOf(c), GLFW_KEY_A + (c - 'A'));
         }


### PR DESCRIPTION
# Pull Request Summary
## What does this PR change?
This PR corrects the inverted vertical orientation of the custom hardware mouse cursor so it renders correctly upright in-game.

# Related Issue
Closes #28

# Type of Change
- [x] Bug fix
- [ ] Feature

# Location
- src/xaos/platform/lwjgl3/input/Keyboard.java

# What it does
- Removed cursor texture flipping code and changed the hot-spot accordingly.

# Testing
- [x] Manual game launch test
- [x] Manual gameplay test
- [x] Build completed successfully