### PR TITLE
Fix full screen to windowed mode transition bug (Closes #36)

### DIFF
--- a/src/xaos/utils/UtilsGL.java
+++ b/src/xaos/utils/UtilsGL.java
@@ -173,6 +173,7 @@ public final class UtilsGL {
 	public static void toggleFullScreen () {
 		try {
 			if (Display.isFullscreen ()) {
+				Display.setFullscreen (false);
 				Display.setDisplayMode (new DisplayMode (lastWindowWidth, lastWindowHeight));
 			} else {
 				lastWindowWidth = Display.getWidth ();


### PR DESCRIPTION
# Pull Request Summary
## What does this PR change?
This PR addresses a windowing display bug where toggling the display state from full screen to windowed mode (via Options -> Graphics -> toggle full-screen)  fails to switch the game out of full screen mode.

# Related Issue
Closes #36

# Type of Change
- [x] Bug fix
- [ ] Feature

# Location
- src/xaos/utils/UtilsGL.java

# What it does
- Add missing call to disable full-screen function before setting the window size.

# Testing
- [x] Manual game launch test
- [x] Manual gameplay test
- [x] Build completed successfully