### PR TITLE
Key remapping bug (closes #41)

### DIFF
--- a/src/xaos/platform/lwjgl3/input/Keyboard.java
+++ b/src/xaos/platform/lwjgl3/input/Keyboard.java
@@ -161,12 +161,32 @@ public final class Keyboard {
             return KEY_NONE;
         }
         Integer key = namesToKeys.get(name.toUpperCase());
-        return key == null ? KEY_NONE : key;
+        if (key == null){
+            key = parseUnknownKey(name);
+            if (key != KEY_NONE)
+                register(name.toUpperCase(), key);
+        }
+        return key;
     }
 
     public static String getKeyName(int key) {
         String name = keysToNames.get(key);
-        return name == null ? "" : name;
+        if  (name == null) {
+            name ="#" + key;
+            register(name, key);
+        }
+        return name;
+    }
+
+    private static Integer parseUnknownKey(String name){
+        if (name.startsWith("#")){
+            try {
+                return Integer.parseInt(name.substring(1));
+            } catch (NumberFormatException _) {
+
+            }
+        }
+        return KEY_NONE;
     }
 
     private static void register(String name, int key) {


### PR DESCRIPTION
# Pull Request Summary
## What does this PR change?
This PR addresses a key remapping bug where remapping controls in Options → Controls, certain keys are saved incorrectly and reset after restarting the game. 

# Related Issue
Closes #41

# Type of Change
- [x] Bug fix
- [ ] Feature

# Location
- src/xaos/platform/lwjgl3/input/Keyboard.java

# What it does
When a previously unknown key is mapped to an action, it is now stored using the format #(keycode) (e.g., #44 for comma).
When loading settings, the game correctly detects this format, restores the keycode, and re‑registers the key name as #(keycode).
This ensures that all valid keys persist correctly across game restarts.

# Testing
- [x] Manual game launch test
- [x] Manual gameplay test
- [x] Build completed successfully
